### PR TITLE
Change method access modifier to public

### DIFF
--- a/Aspire.Hosting.Playwright/BuilderExtensions.cs
+++ b/Aspire.Hosting.Playwright/BuilderExtensions.cs
@@ -84,7 +84,7 @@ public static class BuilderExtensions
 	/// using the specified hostname alias. 'host.docker.internal' is Docker's standard
 	/// hostname for accessing the host machine from containers.
 	/// </remarks>
-	internal static IResourceBuilder<PlaywrightResource> WithHostNetworkAccess(this IResourceBuilder<PlaywrightResource> builder, string hostAlias = "host.docker.internal")
+	public static IResourceBuilder<PlaywrightResource> WithHostNetworkAccess(this IResourceBuilder<PlaywrightResource> builder, string hostAlias = "host.docker.internal")
 	{
 		ArgumentNullException.ThrowIfNull(builder, nameof(builder));
 


### PR DESCRIPTION
Needs to be public to match the README.

```cs
	internal static IResourceBuilder<PlaywrightResource> WithHostNetworkAccess(this IResourceBuilder<PlaywrightResource> builder, string hostAlias = "host.docker.internal")
	{
		ArgumentNullException.ThrowIfNull(builder, nameof(builder));

		return builder.WithContainerRuntimeArgs($"--add-host={hostAlias}:host-gateway");
	}
```